### PR TITLE
Implement async model loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The server implements OpenAI-compatible endpoints:
 - [Models](https://platform.openai.com/docs/api-reference/models/list)
     - ✅ `/v1/models` - List models
     - ✅ `/v1/models/{model}` - Retrieve or Delete model
+    - ✅ `/v1/models/load` - Download a model asynchronously
+    - ✅ `/v1/models/load/{id}` - Check download status
 - [Images](https://platform.openai.com/docs/api-reference/images)
     - ✅ `/v1/images/generations` - Image generation
 - [Embeddings](https://platform.openai.com/docs/api-reference/embeddings)
@@ -326,6 +328,8 @@ MLX Omni Server uses Hugging Face for model downloading and management. When you
 
 - It's recommended to pre-download models through Hugging Face before using them in your service
 - To use a locally downloaded model, simply set the `model` parameter to the local model path
+
+You can trigger a model download in advance using the `/v1/models/load` endpoint. This returns a task identifier which can be polled via `/v1/models/load/{id}` to check the download status.
 
 ```python
 # Using a model from Hugging Face

--- a/src/mlx_omni_server/chat/models/__init__.py
+++ b/src/mlx_omni_server/chat/models/__init__.py
@@ -1,0 +1,4 @@
+from .models import router
+from .model_loader import ModelLoader
+
+__all__ = ["router", "ModelLoader"]

--- a/src/mlx_omni_server/chat/models/model_loader.py
+++ b/src/mlx_omni_server/chat/models/model_loader.py
@@ -1,0 +1,31 @@
+import asyncio
+from typing import Dict, Any
+from uuid import uuid4
+
+from huggingface_hub import snapshot_download
+
+
+class ModelLoader:
+    """Manage background model downloads."""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[str, asyncio.Task] = {}
+        self._status: Dict[str, Dict[str, Any]] = {}
+
+    async def _download(self, model_id: str, task_id: str) -> None:
+        try:
+            await asyncio.to_thread(snapshot_download, repo_id=model_id)
+            self._status[task_id]["status"] = "completed"
+        except Exception as e:  # pragma: no cover - network operations
+            self._status[task_id]["status"] = "failed"
+            self._status[task_id]["error"] = str(e)
+
+    def start(self, model_id: str) -> str:
+        """Start downloading a model in the background."""
+        task_id = uuid4().hex
+        self._status[task_id] = {"status": "in_progress", "model": model_id}
+        self._tasks[task_id] = asyncio.create_task(self._download(model_id, task_id))
+        return task_id
+
+    def get_status(self, task_id: str) -> Dict[str, Any]:
+        return self._status.get(task_id, {"status": "not_found"})

--- a/src/mlx_omni_server/chat/models/models.py
+++ b/src/mlx_omni_server/chat/models/models.py
@@ -1,10 +1,19 @@
 from fastapi import APIRouter, HTTPException, Request
 
+from .model_loader import ModelLoader
 from .models_service import ModelsService
-from .schema import Model, ModelDeletion, ModelList
+from .schema import (
+    Model,
+    ModelDeletion,
+    ModelList,
+    ModelDownloadRequest,
+    ModelDownloadResponse,
+    ModelDownloadStatus,
+)
 
 router = APIRouter(tags=["models"])
 models_service = ModelsService()
+model_loader = ModelLoader()
 
 
 def extract_model_id_from_path(request: Request) -> str:
@@ -74,3 +83,19 @@ async def delete_model(request: Request) -> ModelDeletion:
         return models_service.delete_model(model_id)
     except Exception as e:
         handle_model_error(e)
+
+
+@router.post("/models/load", response_model=ModelDownloadResponse)
+@router.post("/v1/models/load", response_model=ModelDownloadResponse)
+async def load_model(request: ModelDownloadRequest) -> ModelDownloadResponse:
+    """Start background download of a model."""
+    task_id = model_loader.start(request.model)
+    return ModelDownloadResponse(id=task_id, status="in_progress")
+
+
+@router.get("/models/load/{task_id}", response_model=ModelDownloadStatus)
+@router.get("/v1/models/load/{task_id}", response_model=ModelDownloadStatus)
+async def get_load_status(task_id: str) -> ModelDownloadStatus:
+    """Get status of a background model download."""
+    status = model_loader.get_status(task_id)
+    return ModelDownloadStatus(id=task_id, **status)

--- a/src/mlx_omni_server/chat/models/schema.py
+++ b/src/mlx_omni_server/chat/models/schema.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -30,3 +30,24 @@ class ModelDeletion(BaseModel):
     id: str = Field(..., description="The ID of the deleted model")
     object: str = Field(default="model", description="The object type (always 'model')")
     deleted: bool = Field(..., description="Whether the model was deleted")
+
+
+class ModelDownloadRequest(BaseModel):
+    """Request body for starting a model download."""
+
+    model: str = Field(..., description="Model ID from Hugging Face")
+
+
+class ModelDownloadResponse(BaseModel):
+    """Response for a started model download."""
+
+    id: str = Field(..., description="Download task identifier")
+    status: str = Field(..., description="Current status of the task")
+
+
+class ModelDownloadStatus(BaseModel):
+    """Status information about a download task."""
+
+    id: str = Field(..., description="Download task identifier")
+    status: str = Field(..., description="Current status")
+    error: Optional[str] = Field(default=None, description="Error message if any")


### PR DESCRIPTION
## Summary
- add endpoint listing in README and usage notes
- provide asynchronous model download functionality
- add new routes to check download status

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_b_683fe15409ec832ebe83395aef2e2d3b